### PR TITLE
Reg refactor

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,8 +1,8 @@
 [package]
 name = "comb_geom"
 version = "0.1"
-lean_version = "leanprover-community/lean:3.16.2"
+lean_version = "leanprover-community/lean:3.16.3"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "b91909e77e219098a2f8cc031f89d595fe274bd2"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "8729fe211ebd7f2b40924e0f5ff0f6b5b1e56695"}

--- a/src/pregeom/basis.lean
+++ b/src/pregeom/basis.lean
@@ -302,6 +302,7 @@ begin
       dsimp,
       cases a with a ha,
       dsimp at *,
+      change a ≤ _,
       refine le_Sup _,
       tidy,
     }

--- a/src/pregeom/geometrize.lean
+++ b/src/pregeom/geometrize.lean
@@ -1,4 +1,5 @@
 import .basic
+import .pullback
 import ..subtype.helpers
 import data.finset
 
@@ -47,8 +48,7 @@ instance [has_reg_element T] : inhabited (reg T) := ⟨⟨elem,is_regular⟩⟩
 
 local notation `ι` := subtype.val
 
-instance has_cl_instance [has_cl T] : has_cl (reg T) :=
-⟨ λ S, ι ⁻¹' cl (ι '' S) ⟩
+instance has_cl_instance [has_cl T] : has_cl (reg T) := pregeom.pullback.has_cl_instance subtype.val 
 
 /-- The relation used to define a geometry from a pregeomery. -/
 protected def rel [has_cl T] : reg T → reg T → Prop :=
@@ -129,59 +129,12 @@ begin
   }
 end
 
-instance pregeom_instance [pregeom T] : pregeom (reg T) :=
-begin
-  split; intros,
-  {
-    intros s hs,
-    change s.val ∈ _,
-    apply inclusive,
-    exact set.mem_image_of_mem ι hs,
-  },
-  {
-    intros u hu,
-    suffices : ι '' A ≤ ι '' B, by exact monotone this hu,
-    apply set.monotone_image a,
-  },
-  {
-    unfold has_cl.cl,    
-    rw [subtype.image_preimage, cl_reg_set_inter, idempotent],
-  },
-  {
-    change y.val ∈ _,
-    change x.val ∈ _ at a,
-    change x.val ∉ _ at a_1,
-    rw set.image_insert_eq at *,
-    exact exchange a a_1,
-  },
-  {
-    change x.val ∈ _ at a,
-    rcases finchar a with ⟨W,h1,h2⟩,
-    have : ↑W ≤ reg_set T,
-    {
-      refine le_trans h1 _,
-      exact subtype.image_le S,
-    },
-    rcases reg_lift_finset this with ⟨V,rfl⟩,
-    refine ⟨V,_,_⟩,
-    {
-      intros v hv,
-      rw ←subtype.preimage_image S,
-      apply h1,
-      rw finset.coe_image,
-      exact set.mem_image_of_mem ι hv,
-    },
-    {
-      rw finset.coe_image at h2,
-      exact h2,
-    }
-  },
-end
+instance pregeom_instance [pregeom T] : pregeom (reg T) := pregeom.pullback.pregeom_instance subtype.val
 
 @[simp]
-theorem regularity [pregeom T] : cl (∅ : set (reg T)) = ∅ := 
+theorem regularity [has_cl T] : cl (∅ : set (reg T)) = ∅ := 
 begin
-  unfold has_cl.cl,
+  change subtype.val ⁻¹' _ = _,
   rw set.image_empty,
   ext, split; intro hx,
   {

--- a/src/pregeom/pullback.lean
+++ b/src/pregeom/pullback.lean
@@ -1,0 +1,82 @@
+import .basic
+import data.set
+
+open_locale classical
+
+namespace pregeom
+namespace pullback
+
+variables {T : Type*} [pregeom T] {S : Type*} (f : S → T)
+
+include f
+def has_cl_instance : has_cl S := ⟨λ A, f ⁻¹' (cl (f '' A))⟩
+
+def pregeom_instance : pregeom S :=
+{ 
+  inclusive := λ A a ha, 
+  begin
+    change f _ ∈ cl _,
+    apply inclusive,
+    use a,
+    simpa,
+  end,
+  monotone := λ A B inc a ha, 
+  begin
+    change f _ ∈ _,
+    have : f '' A ≤ f '' B, by tidy,
+    apply monotone this,
+    simpa,
+  end,
+  idempotent := λ A,
+  begin
+    change f ⁻¹' cl (f '' ( f ⁻¹' _) ) = f ⁻¹' _,
+    tidy,
+    { 
+      replace a : f x ∈ cl (cl (f '' A)),
+      {
+        refine monotone _ a,
+        tidy,
+      },
+      rwa idempotent at a,
+    },
+    { 
+      apply inclusive,
+      refine ⟨x,_,by refl⟩,
+      simpa,
+    }
+  end,
+  exchange := λ x y S h1 h2, 
+  begin
+    change f y ∈ _,
+    change f x ∉ _ at h2,
+    change f x ∈ _ at h1,
+    rw set.image_insert_eq at *,
+    exact exchange h1 h2,
+  end,
+  finchar := λ x U hx, 
+  begin
+    suffices : ∀ {C : finset T}, (↑C ≤ f '' U → ∃ D : finset S, finset.image f D = C ∧ ↑D ≤ U),
+    {
+      rcases finchar hx with ⟨A, h1, h2⟩,
+      rcases this h1 with ⟨B, h3, h4⟩,
+      refine ⟨B,h4,_⟩,
+      change f x ∈ _,
+      rwa [←finset.coe_image,h3],
+    },
+    refine finset.induction (by finish) _,
+    {
+      intros t E ht ind h,
+      rw finset.coe_insert at h,
+      have : ↑E ≤ f '' U, by {intros e he, apply h, finish},
+      rcases ind this with ⟨D,h1,h2⟩,
+      have : t ∈ f '' U, by {apply h, finish},
+      rcases this with ⟨s,hs,rfl⟩,
+      use insert s D,
+      tidy, 
+    }
+  end,
+  ..show has_cl S, by exact has_cl_instance f
+}
+
+end pullback
+end pregeom

--- a/src/pregeom/pullback.lean
+++ b/src/pregeom/pullback.lean
@@ -79,4 +79,32 @@ def pregeom_instance [pregeom T] : pregeom S :=
 }
 
 end pullback
+
+namespace geom
+namespace pullback
+
+variables {T : Type*} {S : Type*} (f : S → T)
+
+include f
+open function 
+
+def geom_instance [geometry T] : injective f → geometry S := λ inj,
+{
+  cl_singleton := λ x, 
+  begin
+    change f ⁻¹' _ = _,
+    rw [set.image_singleton, geometry.cl_singleton],
+    rw [←set.image_singleton, set.preimage_image_eq],
+    assumption,
+  end,
+  cl_empty := 
+  begin
+    change f ⁻¹' _ = _,
+    rw [set.image_empty, geometry.cl_empty, set.preimage_empty],
+  end,
+  ..show pregeom S, by exact pullback.pregeom_instance f
+}
+
+end pullback
+end geom
 end pregeom

--- a/src/pregeom/pullback.lean
+++ b/src/pregeom/pullback.lean
@@ -9,8 +9,10 @@ namespace pullback
 variables {T : Type*} {S : Type*} (f : S → T)
 
 include f
+/-- The has_cl instance for the pullback by f. -/
 def has_cl_instance [has_cl T] : has_cl S := ⟨λ A, f ⁻¹' (cl (f '' A))⟩
 
+/-- The pregeom instance for the pullback by f. -/
 def pregeom_instance [pregeom T] : pregeom S :=
 { 
   inclusive := λ A a ha, 
@@ -88,6 +90,7 @@ variables {T : Type*} {S : Type*} (f : S → T)
 include f
 open function 
 
+/-- If f is injective, and T is a geometry, then the pullback by f : S → T is a geometry. -/
 def geom_instance [geometry T] : injective f → geometry S := λ inj,
 {
   cl_singleton := λ x, 

--- a/src/pregeom/pullback.lean
+++ b/src/pregeom/pullback.lean
@@ -6,12 +6,12 @@ open_locale classical
 namespace pregeom
 namespace pullback
 
-variables {T : Type*} [pregeom T] {S : Type*} (f : S → T)
+variables {T : Type*} {S : Type*} (f : S → T)
 
 include f
-def has_cl_instance : has_cl S := ⟨λ A, f ⁻¹' (cl (f '' A))⟩
+def has_cl_instance [has_cl T] : has_cl S := ⟨λ A, f ⁻¹' (cl (f '' A))⟩
 
-def pregeom_instance : pregeom S :=
+def pregeom_instance [pregeom T] : pregeom S :=
 { 
   inclusive := λ A a ha, 
   begin

--- a/src/tactics/macros.lean
+++ b/src/tactics/macros.lean
@@ -1,4 +1,8 @@
 import tactic
 
 /-- A silly macro. -/
-meta def tiny_hammer := `[{finish} <|> {tidy, finish} <|> {simp} <|> {dsimp}]
+meta def tiny_hammer := `[ 
+  {finish} <|>
+  {tidy, done} <|>
+  {tidy, finish}
+  ]


### PR DESCRIPTION
This refactors some of the code used to construct a geometry from a pregeometry.

If `f : S -> T` is any function and `T` is a pregeometry, then we can "pullback" by `f` to obtain a pregeometry on `S`.
The construction of the pregeometry instance on `(reg T)` was a special case of this, where `f` is the canonical injection `(reg T) -> T`.

